### PR TITLE
Writer type has a call signature and no `write` method

### DIFF
--- a/messaging/index.d.ts
+++ b/messaging/index.d.ts
@@ -1,1 +1,3 @@
 export function follow<T, U>(previous: T, classOfNext: new (...args: any[]) => U, additionalFields?: Partial<U>): U;
+
+export * from './write';

--- a/messaging/write/index.d.ts
+++ b/messaging/write/index.d.ts
@@ -8,12 +8,13 @@ type CreateWriterOptions = {
   messageStore: MessageStore;
 };
 
-type WriteFn = (message: Message, streamName: string, options?: { expectedVersion?: number }) => Promise<number>;
+interface WriteFn {
+  (message: Message, streamName: string, options?: { expectedVersion?: number }): Promise<number>;
+}
 
-export type Writer = {
-  write: WriteFn;
+export interface Writer extends WriteFn {
   emitter: ClassLike;
   initial: (message: Message, streamName: string) => Promise<number>;
-};
+}
 
 export function createWriter(options: CreateWriterOptions): Writer;


### PR DESCRIPTION
Also, export everything in `write/` in `messaging/` as gearshaft does that.