### PR TITLE
Metadata type added

### DIFF
--- a/messaging/index.d.ts
+++ b/messaging/index.d.ts
@@ -1,3 +1,13 @@
 export function follow<T, U>(previous: T, classOfNext: new (...args: any[]) => U, additionalFields?: Partial<U>): U;
 
+export interface Metadata {
+  follow: Function;
+  globalPosition: number;
+  position: number;
+  causationMessageStreamName?: string;
+  causationMessagePosition?: number;
+  causationMessageGlobalPosition?: number;
+  correlationStreamName?: string;
+  replyStreamName?: string;
+}
 export * from './write';

--- a/messaging/index.d.ts
+++ b/messaging/index.d.ts
@@ -1,13 +1,18 @@
 export function follow<T, U>(previous: T, classOfNext: new (...args: any[]) => U, additionalFields?: Partial<U>): U;
 
-export interface Metadata {
+export type Metadata = {
   follow: Function;
   globalPosition: number;
   position: number;
+  stream: string;
+  time: string;
   causationMessageStreamName?: string;
   causationMessagePosition?: number;
   causationMessageGlobalPosition?: number;
   correlationStreamName?: string;
   replyStreamName?: string;
-}
+} & {
+  [prop: string]: any;
+};
+
 export * from './write';


### PR DESCRIPTION
Awaiting confirmation from Mario that `position` and `globalPosition` are guaranteed, but from reading the gearshaft repo and reasoning about their purpose they seem like they'd have to be.

See implementation of [messaging/message-transforms.js](https://github.com/mpareja/gearshaft/blob/master/messaging/message-transforms.js#L32-L42) (reading events) & [messaging/metadata.js](https://github.com/mpareja/gearshaft/blob/master/messaging/metadata.js) (writing events)

**Mario:**
> You'll find that the `message.metadata` property that a message handler receives will contain any metadata stored in the metadata column of the message store plus the `streamName` , `position` , `globalPosition` and `time` of the specific message record.