### PR TITLE
Clarify & correct Register* types

### DIFF
--- a/consumer/consumer-handler-registry.d.ts
+++ b/consumer/consumer-handler-registry.d.ts
@@ -1,15 +1,23 @@
 import { GenericConstructor } from '../index';
 import { Log } from '../logging';
 
-type ConsumerHandlerFunc<T> = (message: T) => void;
-type ConsumerHandlerRegistry = {
+export interface RegisterHandler {
+  <T>(messageType: GenericConstructor<T>, handler: ConsumerHandlerFunc<T>): void;
+}
+
+export interface RegisterHandlers {
+  (register: RegisterHandler): void;
+}
+
+export type ConsumerHandlerFunc<T> = (message: T) => void;
+export interface ConsumerHandlerRegistry {
   register<T>(messageType: GenericConstructor<T>, handler: ConsumerHandlerFunc<T>): void;
   handle(messageData: any): void;
-};
+}
 
-type ConsumerHandlerCreateOptions = {
+export interface ConsumerHandlerCreateOptions {
   name: string;
   log?: Log;
-};
+}
 
 export function createConsumerHandlerRegistry(options: ConsumerHandlerCreateOptions): ConsumerHandlerRegistry;

--- a/consumer/index.d.ts
+++ b/consumer/index.d.ts
@@ -1,5 +1,6 @@
 import { Log } from '../logging';
-import { GenericConstructor } from '../index';
+import { RegisterHandlers } from './consumer-handler-registry';
+
 import { MessageStore } from '../message-store';
 type Runner = {
   pause: () => Promise<void>;
@@ -12,15 +13,12 @@ type Consumer = {
   dispatch: <T>(messageData: T) => Promise<void>;
   positionStore: any; // TODO: what is this?
 };
-type ConsumerHandlerFunc<T> = (message: T) => void; // TODO: share with consumer handler registry?
-
-type RegisterFn = (register: <T>(messageType: GenericConstructor<T>, handler: ConsumerHandlerFunc<T>) => void) => void;
 
 export function createConsumer(options: {
   log: Log;
   name: string;
   positionUpdateInterval?: number;
-  registerHandlers: RegisterFn;
+  registerHandlers: RegisterHandlers;
   messageStore: MessageStore;
   category: string;
   correlation?: string;

--- a/host/index.d.ts
+++ b/host/index.d.ts
@@ -6,6 +6,6 @@ interface Host extends EventEmitter {
   unpause: () => void;
 }
 
-type RegisterFn = (consumer: Consumer) => void; // TODO: will be a consumer type
-type Register = { register: RegisterFn };
-export function startHost(callback: (register: Register) => void): Host;
+type RegisterConsumer = (consumer: Consumer) => void;
+type RegisterConsumers = { register: RegisterConsumer };
+export function startHost(callback: (register: RegisterConsumers) => void): Host;

--- a/message-store/postgres/index.d.ts
+++ b/message-store/postgres/index.d.ts
@@ -4,7 +4,7 @@ import { PostgresGateway } from '../../';
 type MessageStoreCreateParams = {
   log?: Log;
   host?: string;
-  port?: string;
+  port?: number;
   database?: string;
   user?: string;
   password?: string;


### PR DESCRIPTION
* Clarify naming to match usage in Gearshaft
* Export interfaces over types
* Reuse types when possible

Bonus: Fix DB `port` type (number, not string)

**Note**: This PR needs to be merged for https://github.com/cssat/esit-referral-component/pull/1 to pass CircleCI checks